### PR TITLE
Updated bs-mocha

### DIFF
--- a/bindings/bs-mocha/package.json
+++ b/bindings/bs-mocha/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/bloomberg/bucklescript-addons#readme",
   "dependencies": {
-    "mocha": "^2.5.3",
-    "bs-platform" : "^1.3.3"
+    "bs-platform": "^2.1.0",
+    "mocha": "^4.0.1"
   }
 }

--- a/bindings/bs-mocha/src/bs_mocha.ml
+++ b/bindings/bs-mocha/src/bs_mocha.ml
@@ -23,7 +23,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-external describe : string -> (unit -> unit[@bs]) -> unit = "describe"
+external describe : string -> (unit -> unit) -> unit = "describe"
     [@@bs.val]
 
 external it : string -> (unit -> unit) -> unit = "it"
@@ -59,7 +59,7 @@ let assert_fail = fun msg -> fail () () (Js.Undefined.return msg) ""
 (* assert -- raises an AssertionError which mocha handls better
 *)
 let from_suites name (suite :  (string * ('a -> unit)) list) =
-    describe name (fun [@bs] () ->
+    describe name (fun () ->
         List.iter (fun (name, code) -> it name code) suite)
 
 type eq =
@@ -79,7 +79,7 @@ let close_enough ?(threshold=0.0000001 (* epsilon_float *)) a b =
   abs_float (a -. b) < threshold
 
 let from_pair_suites name (suites :  pair_suites) =
-  describe name (fun [@bs] () ->
+  describe name (fun () ->
       suites |>
       List.iter (fun (name, code) ->
           it name (fun _ ->

--- a/bindings/bs-mocha/src/bs_mocha.mli
+++ b/bindings/bs-mocha/src/bs_mocha.mli
@@ -22,17 +22,45 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
+external describe : string -> (unit -> unit [@bs]) -> unit = "describe"
+    [@@bs.val]
 
-type  eq =
-  | Eq :  'a *'a  ->  eq
-  | Neq : 'a * 'a ->  eq
+external it : string -> (unit -> unit) -> unit = "it"
+    [@@bs.val]
+
+external eq : 'a -> 'a -> unit = "deepEqual"
+    [@@bs.val]
+    [@@bs.module "assert"]
+
+external neq : 'a -> 'a -> unit = "notDeepEqual"
+    [@@bs.val]
+    [@@bs.module "assert"]
+
+external ok : Js.boolean -> unit = "ok"
+    [@@bs.val]
+    [@@bs.module "assert"]
+
+external fail : 'a -> 'a -> string Js.undefined -> string -> unit = "fail"
+    [@@bs.val]
+    [@@bs.module "assert"]
+
+external dump : 'a array -> unit = "console.log" [@@bs.val ] [@@bs.splice]
+external throws : (unit -> unit) -> unit = "throws" [@@bs.val] [@@bs.module "assert"]
+
+val assert_equal : 'a -> 'a -> unit
+val assert_notequal : 'a -> 'a -> unit
+val assert_ok : bool -> unit
+val assert_fail : string -> unit
+val from_suites : string -> (string * (unit -> unit)) list -> unit
+type eq =
+    Eq : 'a * 'a -> eq
+  | Neq : 'a * 'a -> eq
   | Ok : bool -> eq
-  | Approx : float * float ->  eq
-  | ApproxThreshold : float * float * float ->  eq
+  | Approx : float * float -> eq
+  | ApproxThreshold : float * float * float -> eq
   | ThrowAny : (unit -> unit) -> eq
   | Fail : unit -> eq
   | FailWith : string -> eq
-type  pair_suites = (string * (unit ->  eq)) list
-
-val from_suites : string -> (string * (unit -> unit)) list -> unit
-val from_pair_suites : string ->  pair_suites -> unit
+type pair_suites = (string * (unit -> eq)) list
+val close_enough : ?threshold:float -> float -> float -> bool
+val from_pair_suites : string -> pair_suites -> unit

--- a/bindings/bs-mocha/src/bs_mocha.mli
+++ b/bindings/bs-mocha/src/bs_mocha.mli
@@ -22,7 +22,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. *)
 
-external describe : string -> (unit -> unit [@bs]) -> unit = "describe"
+external describe : string -> (unit -> unit) -> unit = "describe"
     [@@bs.val]
 
 external it : string -> (unit -> unit) -> unit = "it"


### PR DESCRIPTION
I updated bs-mocha

- I updated to the latest version of mocha and bs-platform
- I added missing definitions to the interface file (those functions otherwise couldn't be reached without it)
- I removed the `[@bs]` annotations, they seemed to be unnecessary since the bindings worked fine without it (I think `unit -> unit` works the same curried/uncurried because it's unary)

@bobzhang One other thing that I had to do in order to use these bindings is to copy the `bsconfig.json` from the `bucklescript-addons/bindings/bs-mocha` folder to my project's `node_modules/bs-mocha` folder. For some reason all files are there when I install bs-mocha (using `npm install bs-mocha`) except for `bsconfig.json`, so `bsb` never found it. I don't know what's hiding it, I think this is the only thing left to do